### PR TITLE
Fix for firehose offset issue

### DIFF
--- a/src/main/java/com/mcneilio/shokuyoku/format/Firehose.java
+++ b/src/main/java/com/mcneilio/shokuyoku/format/Firehose.java
@@ -59,10 +59,15 @@ public class Firehose {
 
     public Firehose(byte[] byteArray) {
         this.byteArray = byteArray;
+
+        int topicLength = byteArray[1] & 0xff;
+        int msgLength = ((0xFF & byteArray[5]) << 24) | ((0xFF & byteArray[4]) << 16) |
+                ((0xFF & byteArray[3]) << 8) | (0xFF & byteArray[2]);
+
         this.topic = new String(Arrays.copyOfRange(byteArray, 6, 6 +
-                (byteArray[1] & 0xf)));
+                topicLength));
         this.message = new String(Arrays.copyOfRange(byteArray, 7 +
-                (byteArray[1] & 0xf), byteArray.length));
+                topicLength , 7 + topicLength  + msgLength));
     }
 
     public byte[] getByteArray() {


### PR DESCRIPTION
Using 0xf was limiting the topic name length to 16