### PR TITLE
feat: use GitHub Java gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,30 @@
+# https://github.com/github/gitignore/blob/master/Java.gitignore
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Custom ignores
 target
+.idea
+.vscode


### PR DESCRIPTION
This change adds the GitHub [gitignore template for Java](https://github.com/github/gitignore/blob/master/Java.gitignore) to the project. It also ignores IDE settings directories.