### PR TITLE
fix: keys should be in snake case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.22.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/mcneilio/shokuyoku/format/JSONColumnFormat.java
+++ b/src/main/java/com/mcneilio/shokuyoku/format/JSONColumnFormat.java
@@ -25,7 +25,11 @@ public class JSONColumnFormat {
                 flatten( (JSONArray) original.get(key), key);
             }
             else {
-                flattened.put(key.replace(' ','_').toLowerCase(), original.get(key));
+                String snakeCaseKey = key.replace(' ','_')
+                    .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
+                    .replaceAll("([a-z])([A-Z])", "$1_$2")
+                    .toLowerCase();
+                flattened.put(snakeCaseKey, original.get(key));
             }
         });
     }

--- a/src/test/java/com/mcneilio/JSONColumnFormatTest.java
+++ b/src/test/java/com/mcneilio/JSONColumnFormatTest.java
@@ -1,0 +1,51 @@
+package com.mcneilio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mcneilio.shokuyoku.format.JSONColumnFormat;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class JSONColumnFormatTest {
+
+    @Test
+    public void flattenDoesNotContainTopLevelObjects() throws Exception {
+        JSONObject eventMsg = getTestJSON();
+
+        assertThat(eventMsg.has("context")).isFalse();
+        assertThat(eventMsg.has("integrations")).isFalse();
+        assertThat(eventMsg.has("properties")).isFalse();
+        assertThat(eventMsg.has("_metadata")).isFalse();
+    }
+
+    @Test
+    public void flattenMergesTopLevelObjects() throws Exception {
+        JSONObject eventMsg = getTestJSON();
+
+        assertThat(eventMsg.has("context_automation")).isTrue();
+        assertThat(eventMsg.has("integrations_google_analytics")).isTrue();
+        assertThat(eventMsg.has("properties_domain")).isTrue();
+        assertThat(eventMsg.has("_metadata_bundled")).isTrue();
+    }
+
+    @Test
+    public void flattenConvertCamelCaseToSnakeCase() throws Exception {
+        JSONObject eventMsg = getTestJSON();
+
+        assertThat(eventMsg.has("messageid")).isFalse();
+        assertThat(eventMsg.has("message_id")).isTrue();
+    }
+
+    private JSONObject getTestJSON() throws Exception {
+        String path = "src/test/resources";
+        File file = new File(path);
+        String resourcesPath = file.getAbsolutePath() + "/testEvent.json";
+
+        String eventText = new String(Files.readAllBytes(Paths.get(resourcesPath)));
+        JSONObject eventJson = new JSONObject(eventText);
+        return new JSONColumnFormat(eventJson).getFlattened();
+    }
+}

--- a/src/test/resources/testEvent.json
+++ b/src/test/resources/testEvent.json
@@ -1,0 +1,63 @@
+{
+    "integrations": {
+        "Google Analytics": true
+    },
+    "context": {
+        "automation": false,
+        "browser": {
+            "name": "Chrome",
+            "version": "96.0.4664.110",
+            "major": "96"
+        },
+        "device": {},
+        "locale": "en-US",
+        "os": {
+            "name": "Linux",
+            "version": "x86_64"
+        },
+        "screen": {
+            "width": 2048,
+            "height": 1088,
+            "density": 1.25
+        },
+        "page": {
+            "path": "/",
+            "referrer": "",
+            "search": "",
+            "title": "Best Coupons, Loyalty, and Deals",
+            "url": "https://example.com"
+        },
+        "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
+        "library": {
+            "name": "analytics.js",
+            "version": "2.11.0"
+        }
+    },
+    "properties": {
+        "domain": "example.com",
+        "pagePath": "/",
+        "view": "home",
+        "features": [
+            "ab_control_search_landing"
+        ],
+        "roles": [
+            "user"
+        ],
+        "profileId": "abc05faf-a830-428a-8dbc-821cf677ddd2",
+        "hasOrdered": false
+    },
+    "event": "focusWindow",
+    "anonymousId": "59c7897e-10e8-45cf-b8f0-4375c4bdcc44",
+    "timestamp": "2022-01-13T20:25:38.658Z",
+    "type": "track",
+    "writeKey": "hoJ2AjJaErOjhma79jutVyqhc4P25Rxc",
+    "userId": "abc0cc2a-2d62-5fc3-9496-92d7e4559ec8",
+    "sentAt": "2022-01-13T20:25:38.663Z",
+    "_metadata": {
+        "bundled": [
+            "AdRoll"
+        ],
+        "unbundled": []
+    },
+    "messageId": "abc-1d27933936b5010cdd312126def8eb58"
+}


### PR DESCRIPTION
This change adds a test case for checking the conversion of camel case to snake case when flattening event JSON objects, and ensure the tests pass.