### PR TITLE
feat: remove properties_ prefix from keys

### DIFF
--- a/src/main/java/com/mcneilio/shokuyoku/format/JSONColumnFormat.java
+++ b/src/main/java/com/mcneilio/shokuyoku/format/JSONColumnFormat.java
@@ -36,14 +36,16 @@ public class JSONColumnFormat {
 
     private void flatten(JSONObject obj, String prefix) {
         obj.keys().forEachRemaining(key -> {
+            String strippedKey = prefix.equals("properties") ? key : prefix + "_" + key;
+
             if (obj.get(key) instanceof JSONObject) {
-                flatten((JSONObject) obj.get(key), prefix+"_"+key);
+                flatten((JSONObject) obj.get(key), strippedKey);
             }
             else if (obj.get(key) instanceof JSONArray) {
-                flatten( (JSONArray) obj.get(key), prefix+"_"+key);
+                flatten( (JSONArray) obj.get(key), strippedKey);
             }
             else {
-                flattened.put(prefix+"_"+key.replace(' ','_').toLowerCase(), obj.get(key));
+                flattened.put(strippedKey.replace(' ','_').toLowerCase(), obj.get(key));
             }
         });
     }

--- a/src/test/java/com/mcneilio/JSONColumnFormatTest.java
+++ b/src/test/java/com/mcneilio/JSONColumnFormatTest.java
@@ -27,7 +27,6 @@ public class JSONColumnFormatTest {
 
         assertThat(eventMsg.has("context_automation")).isTrue();
         assertThat(eventMsg.has("integrations_google_analytics")).isTrue();
-        assertThat(eventMsg.has("properties_domain")).isTrue();
         assertThat(eventMsg.has("_metadata_bundled")).isTrue();
     }
 
@@ -37,6 +36,14 @@ public class JSONColumnFormatTest {
 
         assertThat(eventMsg.has("messageid")).isFalse();
         assertThat(eventMsg.has("message_id")).isTrue();
+    }
+
+    @Test
+    public void flattenRemovesPropertiesPrefix() throws Exception {
+        JSONObject eventMsg = getTestJSON();
+
+        assertThat(eventMsg.has("properties_domain")).isFalse();
+        assertThat(eventMsg.has("domain")).isTrue();
     }
 
     private JSONObject getTestJSON() throws Exception {


### PR DESCRIPTION
This change removes the `properties_` prefix from keys in the event message before writing to the ORC file.