### PR TITLE
Filter events by the values in their columns

### DIFF
--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -1,5 +1,6 @@
 package com.mcneilio.shokuyoku;
 
+import com.mcneilio.shokuyoku.filter.FilterEventByColumnValue;
 import com.mcneilio.shokuyoku.format.Firehose;
 import com.mcneilio.shokuyoku.format.JSONColumnFormat;
 import com.mcneilio.shokuyoku.model.EventType;
@@ -176,7 +177,9 @@ public class Filter {
                 }
 
                 statsd.increment("filter.forwarded", 1, new String[]{"env:"+System.getenv("STATSD_ENV"),"topic:"+eventName});
-                producer.send(new ProducerRecord<>(System.getenv("KAFKA_OUTPUT_TOPIC"), firehoseMessage.getByteArray()));
+                if (new FilterEventByColumnValue(cleanedObject).shouldForward()) {
+                    producer.send(new ProducerRecord<>(System.getenv("KAFKA_OUTPUT_TOPIC"), firehoseMessage.getByteArray()));
+                }
             }
 
             consumer.commitSync();

--- a/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
+++ b/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
@@ -1,12 +1,12 @@
 package com.mcneilio.shokuyoku.filter;
 
 import org.json.JSONObject;
+import org.mortbay.util.ajax.JSON;
 
 import java.util.ArrayList;
 
 public class FilterEventByColumnValue {
-    public FilterEventByColumnValue(JSONObject event) {
-        this.event = event;
+    public FilterEventByColumnValue() {
         if (System.getenv().containsKey("EVENT_COLUMN_VALUE_FILTER")) {
             for (String filterString: System.getenv("EVENT_COLUMN_VALUE_FILTER").split("|")) {
                 filters.add(new ColumnValueFilter(filterString.split(",")));
@@ -14,7 +14,7 @@ public class FilterEventByColumnValue {
         }
     }
 
-    public boolean shouldForward() {
+    public boolean shouldForward(JSONObject event) {
         if (filters.size() == 0) {
             return true;
         }
@@ -22,9 +22,9 @@ public class FilterEventByColumnValue {
             for (ColumnValueFilter filter : filters) {
                 switch (filter.method.toLowerCase()) {
                     case "contains":
-                        return shouldForwardContains(filter.column, filter.value);
+                        return shouldForwardContains(filter.column, filter.value, event);
                     case "excludes":
-                        return shouldForwardExcludes(filter.column, filter.value);
+                        return shouldForwardExcludes(filter.column, filter.value, event);
                     default:
                         System.out.println("UnknownFilterMethod: " + filter.method);
                 }
@@ -33,7 +33,7 @@ public class FilterEventByColumnValue {
         return true;
     }
 
-    boolean shouldForwardContains(String column, String value) {
+    boolean shouldForwardContains(String column, String value, JSONObject event) {
         if (!event.has(column))
             return false;
         if (event.get(column) == null)
@@ -44,7 +44,7 @@ public class FilterEventByColumnValue {
             return false;
     }
 
-    boolean shouldForwardExcludes(String column, String value) {
+    boolean shouldForwardExcludes(String column, String value, JSONObject event) {
         if (!event.has(column))
             return true;
         if (event.get(column) == null)
@@ -55,7 +55,6 @@ public class FilterEventByColumnValue {
             return true;
     }
 
-    private JSONObject event;
     private ArrayList<ColumnValueFilter> filters = new ArrayList<>();
 
     private class ColumnValueFilter {

--- a/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
+++ b/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
@@ -34,6 +34,10 @@ public class FilterEventByColumnValue {
     }
 
     boolean shouldForwardContains(String column, String value) {
+        if (!event.has(column))
+            return false;
+        if (event.get(column) == null)
+            return false;
         if (event.get(column).toString().contains(value))
             return true;
         else
@@ -41,6 +45,10 @@ public class FilterEventByColumnValue {
     }
 
     boolean shouldForwardExcludes(String column, String value) {
+        if (!event.has(column))
+            return true;
+        if (event.get(column) == null)
+            return true;
         if (event.get(column).toString().contains(value))
             return false;
         else

--- a/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
+++ b/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
@@ -1,0 +1,61 @@
+package com.mcneilio.shokuyoku.filter;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+public class FilterEventByColumnValue {
+    public FilterEventByColumnValue(JSONObject event) {
+        this.event = event;
+        if (System.getenv().containsKey("EVENT_COLUMN_VALUE_FILTER")) {
+            for (String filterString: System.getenv("EVENT_COLUMN_VALUE_FILTER").split("|")) {
+                filters.add(new ColumnValueFilter(filterString.split(",")));
+            }
+        }
+    }
+
+    public boolean shouldForward() {
+        if (filters.size() == 0) {
+            return true;
+        }
+        else {
+            for (ColumnValueFilter filter : filters) {
+                switch (filter.method.toLowerCase()) {
+                    case "contains":
+                        return shouldForwardContains(filter.column, filter.value);
+                    case "excludes":
+                        return shouldForwardExcludes(filter.column, filter.value);
+                    default:
+                        System.out.println("UnknownFilterMethod: " + filter.method);
+                }
+            }
+        }
+        return true;
+    }
+
+    boolean shouldForwardContains(String column, String value) {
+        if (event.get(column).toString().contains(value))
+            return true;
+        else
+            return false;
+    }
+
+    boolean shouldForwardExcludes(String column, String value) {
+        if (event.get(column).toString().contains(value))
+            return false;
+        else
+            return true;
+    }
+
+    private JSONObject event;
+    private ArrayList<ColumnValueFilter> filters = new ArrayList<>();
+
+    private class ColumnValueFilter {
+        ColumnValueFilter(String[] filterComponents) {
+            this.column = filterComponents[0];
+            this.method = filterComponents[1];
+            this.value = filterComponents[2];
+        }
+        String column, method, value;
+    }
+}

--- a/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
+++ b/src/main/java/com/mcneilio/shokuyoku/filter/FilterEventByColumnValue.java
@@ -9,7 +9,8 @@ public class FilterEventByColumnValue {
     public FilterEventByColumnValue() {
         if (System.getenv().containsKey("EVENT_COLUMN_VALUE_FILTER")) {
             for (String filterString: System.getenv("EVENT_COLUMN_VALUE_FILTER").split("|")) {
-                filters.add(new ColumnValueFilter(filterString.split(",")));
+                String[] filterComponents = filterString.split(",");
+                filters.add(new ColumnValueFilter(filterComponents[0], filterComponents[1], filterComponents[2]));
             }
         }
     }
@@ -58,10 +59,10 @@ public class FilterEventByColumnValue {
     private ArrayList<ColumnValueFilter> filters = new ArrayList<>();
 
     private class ColumnValueFilter {
-        ColumnValueFilter(String[] filterComponents) {
-            this.column = filterComponents[0];
-            this.method = filterComponents[1];
-            this.value = filterComponents[2];
+        ColumnValueFilter(String column, String method, String value) {
+            this.column = column;
+            this.method = method;
+            this.value = value;
         }
         String column, method, value;
     }


### PR DESCRIPTION
Adds a simple filter mechanism that reads optional environment variable `EVENT_COLUMN_VALUE_FILTER`.

`EVENT_COLUMN_VALUE_FILTER` filter statements are split by pipe `|` 
Each filterstatement contains a 3-tuple describing: `column,method,value`

`column` provides the post-flatten key to be evaluated
`method` provides the method to use for comparison
`value` provides the value to compare to

Currently only supports String methods `contains` and `excludes`

`contains` will return true if the provided `column` contains the provided `value` (false if the column dne or is null)
`excludes` will return true if the provided `column` does not contain the provided `value` (true if the column dne or is null)