### PR TITLE
feat: support optional consumer and producer configs

### DIFF
--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -72,11 +72,8 @@ public class Filter {
 
         statsd = Statsd.getInstance();
 
-        Properties consumerProps = createConsumerProps();
-        Properties producerProps = createProducerProps();
-
-        KafkaConsumer<String,byte[]> consumer = new KafkaConsumer<>(consumerProps);
-        KafkaProducer<String,byte[]> producer = new KafkaProducer<>(producerProps);
+        KafkaConsumer<String,byte[]> consumer = new KafkaConsumer<>(createConsumerProps());
+        KafkaProducer<String,byte[]> producer = new KafkaProducer<>(createProducerProps());
 
         consumer.subscribe(Arrays.asList(System.getenv("KAFKA_INPUT_TOPIC")));
 

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -214,6 +214,10 @@ public class Filter {
         consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
         consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+        if (System.getenv("CLIENT_RACK") != null) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("CLIENT_RACK"));
+        }
         return consumerProps;
     }
 

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -71,27 +71,16 @@ public class Filter {
         boolean allowInvalidCoercions = "true".equals(System.getenv("ALLOW_INVALID_COERCIONS"));
 
         statsd = Statsd.getInstance();
-        Properties consumerProps = new Properties();
-        consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
-        consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, System.getenv("KAFKA_GROUP_ID"));
-        consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
-        Properties producerProps = new Properties();
-        producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
-        producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+        Properties consumerProps = createConsumerProps();
+        Properties producerProps = createProducerProps();
 
         KafkaConsumer<String,byte[]> consumer = new KafkaConsumer<>(consumerProps);
-
         KafkaProducer<String,byte[]> producer = new KafkaProducer<>(producerProps);
 
         consumer.subscribe(Arrays.asList(System.getenv("KAFKA_INPUT_TOPIC")));
 
         boolean littleEndian = System.getenv("ENDIAN") != null && System.getenv("ENDIAN").equals("little");
-
 
         Set<String> dropEvents = null;
         if (System.getenv("DROP_EVENT_TOPICS") !=null) {
@@ -197,6 +186,25 @@ public class Filter {
 
             consumer.commitSync();
         }
+    }
+
+    private Properties createProducerProps() {
+        Properties producerProps = new Properties();
+        producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
+        producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+        producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+        return producerProps;
+    }
+
+    private Properties createConsumerProps() {
+        Properties consumerProps = new Properties();
+        consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
+        consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, System.getenv("KAFKA_GROUP_ID"));
+        consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+        consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        return consumerProps;
     }
 
     static StatsDClient statsd;

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -218,6 +218,9 @@ public class Filter {
         if (System.getenv("CLIENT_RACK") != null) {
             consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("CLIENT_RACK"));
         }
+        if (System.getenv("FETCH_MIN_BYTES") != null) {
+            consumerProps.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("FETCH_MIN_BYTES"));
+        }
         return consumerProps;
     }
 

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -80,8 +80,7 @@ public class Filter {
         consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
         Properties producerProps = new Properties();
-        producerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
-
+        producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
         producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
 

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -193,6 +193,16 @@ public class Filter {
         producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
         producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+
+        if (System.getenv("LINGER_MS") != null) {
+            producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, System.getenv("LINGER_MS"));
+        }
+        if (System.getenv("BATCH_SIZE") != null) {
+            producerProps.setProperty(ProducerConfig.BATCH_SIZE_CONFIG, System.getenv("BATCH_SIZE"));
+        }
+        if (System.getenv("ACKS") != null) {
+            producerProps.setProperty(ProducerConfig.ACKS_CONFIG, System.getenv("ACKS"));
+        }
         return producerProps;
     }
 

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -191,14 +191,14 @@ public class Filter {
         producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
 
-        if (System.getenv("LINGER_MS") != null) {
-            producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, System.getenv("LINGER_MS"));
+        if (System.getenv("KAFKA_LINGER_MS") != null) {
+            producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, System.getenv("KAFKA_LINGER_MS"));
         }
-        if (System.getenv("BATCH_SIZE") != null) {
-            producerProps.setProperty(ProducerConfig.BATCH_SIZE_CONFIG, System.getenv("BATCH_SIZE"));
+        if (System.getenv("KAFKA_BATCH_SIZE") != null) {
+            producerProps.setProperty(ProducerConfig.BATCH_SIZE_CONFIG, System.getenv("KAFKA_BATCH_SIZE"));
         }
-        if (System.getenv("ACKS") != null) {
-            producerProps.setProperty(ProducerConfig.ACKS_CONFIG, System.getenv("ACKS"));
+        if (System.getenv("KAFKA_ACKS") != null) {
+            producerProps.setProperty(ProducerConfig.ACKS_CONFIG, System.getenv("KAFKA_ACKS"));
         }
         return producerProps;
     }
@@ -212,11 +212,11 @@ public class Filter {
         consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
         consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
-        if (System.getenv("CLIENT_RACK") != null) {
-            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("CLIENT_RACK"));
+        if (System.getenv("KAFKA_CLIENT_RACK") != null) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("KAFKA_CLIENT_RACK"));
         }
-        if (System.getenv("FETCH_MIN_BYTES") != null) {
-            consumerProps.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("FETCH_MIN_BYTES"));
+        if (System.getenv("KAFKA_FETCH_MIN_BYTES") != null) {
+            consumerProps.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("KAFKA_FETCH_MIN_BYTES"));
         }
         return consumerProps;
     }

--- a/src/main/java/com/mcneilio/shokuyoku/Worker.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Worker.java
@@ -31,15 +31,9 @@ public class Worker {
 
         verifyEnvironment();
         System.out.println("shokuyoku will start processing requests from topic: " + System.getenv("KAFKA_TOPIC"));
-        Properties props = new Properties();
-        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
-        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, System.getenv("KAFKA_GROUP_ID"));
-        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        Properties props = createConsumerProps();
 
-        String kafkaTopic = System.getenv("WORKER_KAFKA_TOPIC")!=null ? System.getenv("WORKER_KAFKA_TOPIC") : System.getenv("KAFKA_TOPIC");
+        String kafkaTopic = System.getenv("WORKER_KAFKA_TOPIC") != null ? System.getenv("WORKER_KAFKA_TOPIC") : System.getenv("KAFKA_TOPIC");
 
         this.descriptionProvider = new HiveDescriptionProvider();
         this.databaseName = System.getenv("HIVE_DATABASE");
@@ -48,6 +42,22 @@ public class Worker {
         this.littleEndian = System.getenv("ENDIAN") != null && System.getenv("ENDIAN").equals("little");
 
         statsd = Statsd.getInstance();
+    }
+
+    private Properties createConsumerProps() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_SERVERS"));
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, System.getenv("KAFKA_GROUP_ID"));
+        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+        if (System.getenv("CLIENT_RACK") != null) {
+            props.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("CLIENT_RACK"));
+        }
+
+        return props;
     }
 
 

--- a/src/main/java/com/mcneilio/shokuyoku/Worker.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Worker.java
@@ -56,6 +56,9 @@ public class Worker {
         if (System.getenv("CLIENT_RACK") != null) {
             props.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("CLIENT_RACK"));
         }
+        if (System.getenv("FETCH_MIN_BYTES") != null) {
+            props.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("FETCH_MIN_BYTES"));
+        }
 
         return props;
     }

--- a/src/main/java/com/mcneilio/shokuyoku/Worker.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Worker.java
@@ -31,13 +31,12 @@ public class Worker {
 
         verifyEnvironment();
         System.out.println("shokuyoku will start processing requests from topic: " + System.getenv("KAFKA_TOPIC"));
-        Properties props = createConsumerProps();
 
         String kafkaTopic = System.getenv("WORKER_KAFKA_TOPIC") != null ? System.getenv("WORKER_KAFKA_TOPIC") : System.getenv("KAFKA_TOPIC");
 
         this.descriptionProvider = new HiveDescriptionProvider();
         this.databaseName = System.getenv("HIVE_DATABASE");
-        this.consumer = new KafkaConsumer<>(props);
+        this.consumer = new KafkaConsumer<>(createConsumerProps());
         this.consumer.subscribe(Arrays.asList(kafkaTopic));
         this.littleEndian = System.getenv("ENDIAN") != null && System.getenv("ENDIAN").equals("little");
 

--- a/src/main/java/com/mcneilio/shokuyoku/Worker.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Worker.java
@@ -52,11 +52,11 @@ public class Worker {
         props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
         props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
-        if (System.getenv("CLIENT_RACK") != null) {
-            props.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("CLIENT_RACK"));
+        if (System.getenv("KAFKA_CLIENT_RACK") != null) {
+            props.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, System.getenv("KAFKA_CLIENT_RACK"));
         }
-        if (System.getenv("FETCH_MIN_BYTES") != null) {
-            props.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("FETCH_MIN_BYTES"));
+        if (System.getenv("KAFKA_FETCH_MIN_BYTES") != null) {
+            props.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("KAFKA_FETCH_MIN_BYTES"));
         }
 
         return props;


### PR DESCRIPTION
This change adds the following optional consumer and producer configs via the following environment variables:

### Consumer
- `CLIENT_RACK` (sets "client.rack" to support [KIP-392](https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica))
- `FETCH_MIN_BYTES` ("fetch.min.bytes")

### Producer
- `BATCH_SIZE` ("batch.size")
- `LINGER_MS` ("linger.ms")
- `ACKS` ("acks")