### PR TITLE
Introducing orcmaker library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>3.3.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-runtime</artifactId>
       <version>3.3.6</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,16 @@
       <artifactId>guava</artifactId>
       <version>31.1-jre</version>
     </dependency>
+    <dependency>
+      <groupId>com.mcneilio</groupId>
+      <artifactId>orcmaker</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client-runtime</artifactId>
+      <version>3.3.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriver.java
+++ b/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriver.java
@@ -51,6 +51,11 @@ public class BasicEventDriver implements EventDriver, com.mcneilio.orcmaker.Even
 
     private JSONToOrc[] orcers;
 
+    public void addMessage(String message) {
+        JSONObject msg = new JSONObject(message);
+        addMessage(msg);
+    }
+
     @Override
     public void addMessage(JSONObject msg2) {
         long t = Instant.now().toEpochMilli();

--- a/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriver.java
+++ b/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriver.java
@@ -30,7 +30,7 @@ import java.util.function.Consumer;
  * BasicEventDriver takes raw JSONObjects and adds them to an ORC file. On an interval or if a certain size
  * is reached, the ORC file is sent to the storageDriver.
  */
-public class BasicEventDriver implements EventDriver {
+public class BasicEventDriver implements EventDriver, com.mcneilio.orcmaker.EventDriver {
 
     private interface JSONToOrc {
         void addObject(ColumnVector columnVector, int idx, Object obj);

--- a/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriverOld.java
+++ b/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriverOld.java
@@ -43,6 +43,11 @@ public class BasicEventDriverOld implements EventDriver, com.mcneilio.orcmaker.E
         this.statsd = Statsd.getInstance();
     }
 
+    public void addMessage(String message) {
+        JSONObject msg = new JSONObject(message);
+        addMessage(msg);
+    }
+
     @Override
     public void addMessage(JSONObject msg) {
         long t = Instant.now().toEpochMilli();

--- a/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriverOld.java
+++ b/src/main/java/com/mcneilio/shokuyoku/driver/BasicEventDriverOld.java
@@ -28,7 +28,7 @@ import java.util.UUID;
  * BasicEventDriver takes raw JSONObjects and adds them to an ORC file. On an interval or if a certain size
  * is reached, the ORC file is sent to the storageDriver.
  */
-public class BasicEventDriverOld implements EventDriver {
+public class BasicEventDriverOld implements EventDriver, com.mcneilio.orcmaker.EventDriver {
 
     public BasicEventDriverOld(String eventName, String date, TypeDescription typeDescription, StorageDriver storageDriver) {
         this.eventName = eventName;

--- a/src/test/java/com/mcneilio/shokuyoku/driver/BasicEventDriverBenchmark.java
+++ b/src/test/java/com/mcneilio/shokuyoku/driver/BasicEventDriverBenchmark.java
@@ -4,15 +4,15 @@ import com.mcneilio.shokuyoku.helpers.SimpleTypeDescriptionProvider;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 public class BasicEventDriverBenchmark {
 
     @Test
-    public void originalTest() throws IOException {
+    public void originalTest() throws Exception {
         String basePath = Files.createTempDirectory("tmpDirPrefix").toFile().getAbsolutePath();
         LocalStorageDriver localStorageDriver = new LocalStorageDriver(basePath);
 
@@ -27,19 +27,32 @@ public class BasicEventDriverBenchmark {
         BasicEventDriver basicEventDriverNew = new BasicEventDriver("event_name", "2022-01-01", simpleTypeDescriptionProvider.getInstance("test", "event_name"), localStorageDriver);
         BasicEventDriverOld basicEventDriverOld = new BasicEventDriverOld("event_name", "2022-01-01", simpleTypeDescriptionProvider.getInstance("test", "event_name"), localStorageDriver);
 
+        Properties props = new Properties();
+        props.setProperty("storage.driver", "local");
+        props.setProperty("storage.local.path", basePath);
+        props.setProperty("statsd.prefix", "");
+        props.setProperty("statsd.host", "localhost");
+        props.setProperty("statsd.port", "8125");
+        props.setProperty("statsd.flush.ms", "1000");
+        props.setProperty("statsd.env", "");
+        props.setProperty("event.date", "2022-01-01");
+        props.setProperty("event.name", "event_name");
+        com.mcneilio.orcmaker.BasicEventDriver basicEventDriverOrcMaker = new com.mcneilio.orcmaker.BasicEventDriver(props, simpleTypeDescriptionProvider.getInstance("test", "event_name"));
+
 
 
 
         runEventDriver(basicEventDriverNew, 10000000, "New");
-
-    runEventDriver(basicEventDriverOld, 10000000, "Old");
-        runEventDriver(basicEventDriverNew, 10000000, "New");
-
         runEventDriver(basicEventDriverOld, 10000000, "Old");
+        runEventDriver(basicEventDriverOrcMaker, 10000000, "OrcMaker");
+
+        runEventDriver(basicEventDriverNew, 10000000, "New");
+        runEventDriver(basicEventDriverOld, 10000000, "Old");
+        runEventDriver(basicEventDriverOrcMaker, 10000000, "OrcMaker");
 
     }
 
-    private static void runEventDriver(EventDriver basicEventDriver, int count, String prefix) {
+    private static void runEventDriver(com.mcneilio.orcmaker.EventDriver basicEventDriver, int count, String prefix) {
         long startMS = System.currentTimeMillis();
         for(int i=0;i<count; i++) {
             JSONObject jsonObject = new JSONObject();


### PR DESCRIPTION
This moves to using the orcmaker library in place of the EventDriver and subordinate components. In addition, it moves to factory classes for the orcers, reducing memory overhead and slightly improving performance.

Output from `BasicEventDriverBenchmark` below. `new` represents the latest code in shokuyoku. `old` represents the class with old in the name in shokuyoku. `OrcMaker` represents the new library code.

```

Flushing: event_name
New Total Time: 9802
Flushing: event_name
Old Total Time: 8018
Flushing: event_name
OrcMaker Total Time: 8750
Flushing: event_name
New Total Time: 9483
Flushing: event_name
Old Total Time: 7950
Flushing: event_name
OrcMaker Total Time: 8575
```

Future PR will remove classes replaced by the library. Future plans for the library include improved testing, speed improvements and improved configuration.