### PR TITLE
feat: add support for setting security.protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ AWS_ACCESS_KEY_ID environment variable should be set https://docs.aws.amazon.com
 AWS_SECRET_ACCESS_KEY environment variable should be set https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 S3_BUCKET environment variable should contain the bucket to write events to. e.g. my-event-bucket
 ORC_BATCH_SIZE environment variable should contain the number of records per orc batch. e.g. 1024
+KAFKA_SECURITY_PROTOCOL environment variable should be one of PLAINTEXT or SSL
 ```
 
 ## Development

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -200,6 +200,9 @@ public class Filter {
         if (System.getenv("KAFKA_ACKS") != null) {
             producerProps.setProperty(ProducerConfig.ACKS_CONFIG, System.getenv("KAFKA_ACKS"));
         }
+        if (System.getenv("KAFKA_SECURITY_PROTOCOL") != null) {
+            producerProps.setProperty(KAFKA_SECURITY_PROTOCOL, System.getenv("KAFKA_SECURITY_PROTOCOL"));
+        }
         return producerProps;
     }
 
@@ -218,8 +221,12 @@ public class Filter {
         if (System.getenv("KAFKA_FETCH_MIN_BYTES") != null) {
             consumerProps.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("KAFKA_FETCH_MIN_BYTES"));
         }
+        if (System.getenv("KAFKA_SECURITY_PROTOCOL") != null) {
+            consumerProps.setProperty(KAFKA_SECURITY_PROTOCOL, System.getenv("KAFKA_SECURITY_PROTOCOL"));
+        }
         return consumerProps;
     }
 
     static StatsDClient statsd;
+    private static final String KAFKA_SECURITY_PROTOCOL = "security.protocol";
 }

--- a/src/main/java/com/mcneilio/shokuyoku/Worker.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Worker.java
@@ -58,6 +58,9 @@ public class Worker {
         if (System.getenv("KAFKA_FETCH_MIN_BYTES") != null) {
             props.setProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, System.getenv("KAFKA_FETCH_MIN_BYTES"));
         }
+        if (System.getenv("KAFKA_SECURITY_PROTOCOL") != null) {
+            props.setProperty(KAFKA_SECURITY_PROTOCOL, System.getenv("KAFKA_SECURITY_PROTOCOL"));
+        }
 
         return props;
     }
@@ -206,6 +209,8 @@ public class Worker {
             System.exit(1);
         }
     }
+
+    private static final String KAFKA_SECURITY_PROTOCOL = "security.protocol";
 
     private final boolean littleEndian;
     String databaseName;


### PR DESCRIPTION
This change allows the user to set the security protocol to either PLAINTEXT or SSL. (SASL based auths not yet supported inside shokuyoku). This will allow clients to connect to SSL-enabled Kafka clusters.