### PR TITLE
rafactor: simplify toggling the error filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ AWS_SECRET_ACCESS_KEY environment variable should be set https://docs.aws.amazon
 S3_BUCKET environment variable should contain the bucket to write events to. e.g. my-event-bucket
 ORC_BATCH_SIZE environment variable should contain the number of records per orc batch. e.g. 1024
 KAFKA_SECURITY_PROTOCOL environment variable should be one of PLAINTEXT or SSL
-ENABLE_FILTER_ERROR environment variable to enabling sending filtered events to an error topic.a (boolean)
 ```
 
 ## Development

--- a/src/main/java/com/mcneilio/shokuyoku/Filter.java
+++ b/src/main/java/com/mcneilio/shokuyoku/Filter.java
@@ -69,7 +69,6 @@ public class Filter {
         boolean checkSimilar = "true".equals(System.getenv("CHECK_SIMILAR"));
         boolean ignoreNulls = "true".equals(System.getenv("IGNORE_NULLS"));
         boolean allowInvalidCoercions = "true".equals(System.getenv("ALLOW_INVALID_COERCIONS"));
-        boolean enableFilterError = "true".equals(System.getenv("ENABLE_FILTER_ERROR"));
 
         statsd = Statsd.getInstance();
 
@@ -146,7 +145,7 @@ public class Filter {
                 JSONSchemaDictionary.EventTypeJSONSchema eventTypeJSONSchema = orcJSONSchemaDictionary.getEventJSONSchema(eventName);
 
                 if (eventTypeJSONSchema == null) {
-                    if (enableFilterError) {
+                    if (System.getenv("KAFKA_ERROR_TOPIC") != null) {
                         producer.send(new ProducerRecord<>(System.getenv("KAFKA_ERROR_TOPIC"), record.value()));
                     }
                     statsd.increment("filter.skipped", 1, new String[]{"env:"+System.getenv("STATSD_ENV"),"topic:"+eventName});
@@ -158,7 +157,7 @@ public class Filter {
 
                 if (filter.getFilterCount() > 0) {
                     statsd.histogram("filter.error", filter.getFilterCount(), new String[]{"env:"+System.getenv("STATSD_ENV"),"topic:"+eventName});
-                    if (enableFilterError) {
+                    if (System.getenv("KAFKA_ERROR_TOPIC") != null) {
                         producer.send(new ProducerRecord<>(System.getenv("KAFKA_ERROR_TOPIC"), record.value()));
                     }
                 }


### PR DESCRIPTION
Instead of tracking an additional environment variable, this change makes the KAFKA_ERROR_TOPIC optional, where it will only be used if provided.