### PR TITLE
fix: update tests

### DIFF
--- a/src/test/java/com/mcneilio/shokuyoku/driver/BasicEventDriverBenchmark.java
+++ b/src/test/java/com/mcneilio/shokuyoku/driver/BasicEventDriverBenchmark.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class BasicEventDriverBenchmark {
 
     @Test
-    public void originalTest() throws IOException {
+    public void originalTest() throws Exception {
         String basePath = Files.createTempDirectory("tmpDirPrefix").toFile().getAbsolutePath();
         LocalStorageDriver localStorageDriver = new LocalStorageDriver(basePath);
 

--- a/src/test/java/com/mcneilio/shokuyoku/format/FirehoseTest.java
+++ b/src/test/java/com/mcneilio/shokuyoku/format/FirehoseTest.java
@@ -68,7 +68,7 @@ public class FirehoseTest {
         environmentVariables.set("ENDIAN", "little");
         environmentVariables.setup();
         Firehose firehoseMessage = new Firehose(testTopic, testMessage.toString());
-        Firehose decodedMessage = new Firehose(firehoseMessage.getByteArray(), false);
+        Firehose decodedMessage = new Firehose(firehoseMessage.getByteArray(), true);
 
         assertThat(decodedMessage.getTopic()).isEqualTo("test_topic");
     }


### PR DESCRIPTION
This changes makes two corrections in the test suite:

1. OriginalTest needs to throw an Exception in the signature to catch any exceptions thrown by `simpleTypeDescriptionProvider.getInstance()` [here](https://github.com/mcneiljt/shokuyoku/blob/main/src/main/java/com/mcneilio/shokuyoku/util/MemoryDescriptionProvider.java#L25)
2. Firehose test should mark little endianness as true