### PR TITLE
Enable REDIS Cache for Hive Metastore FieldSchema data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,11 @@
       <artifactId>guava</artifactId>
       <version>31.1-jre</version>
     </dependency>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>5.0.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/mcneilio/shokuyoku/App.java
+++ b/src/main/java/com/mcneilio/shokuyoku/App.java
@@ -2,7 +2,8 @@ package com.mcneilio.shokuyoku;
 
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
-import java.util.Locale;
+import com.mcneilio.shokuyoku.util.OrcJSONSchemaDictionaryCache;
+
 
 /**
  * Entrypoint to the shokuyoku daemon
@@ -18,6 +19,14 @@ public class App {
                 "To begin listening for events pass the 'service' argument.",
                 "To begin processing data pass the 'worker' argument."
             ));
+        }
+
+        if (args[0].equals("init_cache")) {
+            System.out.println("Initialize and populate redis cache");
+            OrcJSONSchemaDictionaryCache orcJSONSchemaDictionaryCache = new OrcJSONSchemaDictionaryCache();
+            orcJSONSchemaDictionaryCache.populateCache();
+
+            return;
         }
 
         if (args[0].equals("service") || args[0].equals("standalone")) {

--- a/src/main/java/com/mcneilio/shokuyoku/util/JSONSchemaDictionary.java
+++ b/src/main/java/com/mcneilio/shokuyoku/util/JSONSchemaDictionary.java
@@ -118,7 +118,7 @@ public class JSONSchemaDictionary {
         }
     }
 
-    protected Map<String, EventTypeJSONSchema> eventTypes = new HashMap<>();
+    final protected Map<String, EventTypeJSONSchema> eventTypes = new HashMap<>();
 
     public EventTypeJSONSchema getEventJSONSchema(String eventName){
         return eventTypes.get(eventName);

--- a/src/main/java/com/mcneilio/shokuyoku/util/OrcJSONSchemaDictionaryCache.java
+++ b/src/main/java/com/mcneilio/shokuyoku/util/OrcJSONSchemaDictionaryCache.java
@@ -1,0 +1,172 @@
+package com.mcneilio.shokuyoku.util;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.thrift.TException;
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import redis.clients.jedis.JedisPooled;
+
+public class OrcJSONSchemaDictionaryCache {
+
+    private JedisPooled jedis = null;
+
+    public OrcJSONSchemaDictionaryCache() {
+        connect();
+    }
+
+    private void connect() {
+        try {
+            String host = System.getenv("REDIS_HOST");
+            String sslEnabled = System.getenv("REDIS_SSL_ENABLED");
+            String port = System.getenv("REDIS_PORT");
+
+            jedis = new JedisPooled(host, Integer.parseInt(port), Boolean.parseBoolean(sslEnabled));
+        } catch (Exception ex) {
+            System.out.println("Error instantiating and connecting to the REDIS cache: " + ex);
+            ex.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    public void populateCache(){
+        String hiveURL = System.getenv("HIVE_URL");
+        String databaseName = System.getenv("HIVE_DATABASE");
+
+        System.out.println("HIVE: " + hiveURL + "/" + databaseName);
+
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set("hive.metastore.local", "false");
+
+        hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, hiveURL);
+        hiveConf.set(HiveConf.ConfVars.PREEXECHOOKS.varname, "");
+        hiveConf.set(HiveConf.ConfVars.POSTEXECHOOKS.varname, "");
+        hiveConf.set(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY.varname, "false");
+
+        try {
+            HiveMetaStoreClient hiveMetaStoreClient = new HiveMetaStoreClient(hiveConf, null);
+
+            List<String> tableNames = hiveMetaStoreClient.getAllTables(databaseName);
+
+            System.out.println("Hive metastore returning " + tableNames.size() + " table names");
+
+            // Set the list of event / tables in the cache
+
+            jedis.set("eventNames", String.join(",", tableNames));
+
+            ExecutorService executors = Executors.newFixedThreadPool(10);
+            for(final String tableName : tableNames) {
+                executors.submit(() -> {
+                    System.out.println("Fetching Orc Table: " + tableName);
+
+                    List<FieldSchema> fs;
+
+                    try {
+                        HiveMetaStoreClient hiveMetaStoreClient1 = new HiveMetaStoreClient(hiveConf, null);
+                        fs = hiveMetaStoreClient1.getSchema(databaseName, tableName);
+
+                        if (fs == null || fs.size() == 0) {
+                            System.out.println("Table / event schema not found: " + tableName + ". Exiting.");
+                            System.exit(1);
+                        }
+
+                        JSONArray json = new JSONArray(fs);
+                        jedis.set(tableName, json.toString());
+
+                        System.out.println("Fetched Orc Table: " + tableName);
+                    }
+                    catch(TException ex) {
+                        System.out.println(ex);
+                        ex.printStackTrace();
+                        System.exit(1);
+                    }
+
+                });
+            }
+
+            System.out.println("Wait for executors to complete");
+
+            executors.shutdown();
+
+            if (!executors.awaitTermination(10, TimeUnit.MINUTES)) {
+                System.out.println("Schema load timed out after 10 minutes");
+                System.exit(1);
+            }
+
+            System.out.println("Executors completed");
+        }
+        catch(Exception ex){
+            System.err.println("ex");
+            ex.printStackTrace();
+
+            // if an error occurs, exit with a status code of 1
+            System.exit(1);
+        }
+        finally {
+            try{
+                closeCache();
+            }
+            catch(Exception ex){
+                System.err.println(ex);
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    // returns a list<String> of event / table names
+    public List<String> getEventNameList() {
+        if (jedis == null)
+            connect();
+
+        String eventNames = jedis.get("eventNames");
+        return eventNames != null ? new ArrayList<>(Arrays.asList(StringUtils.split(eventNames, ','))) : null;
+    }
+
+    // returns the List<FieldSchema> for the given event / table name
+
+    public List<FieldSchema> getCachedSchema(String eventName) {
+        if (jedis == null) {
+            connect();
+        }
+
+        String schema = jedis.get(eventName);
+
+        if (schema == null)
+            return null;
+
+        JSONArray json = new JSONArray(schema);
+
+        List<FieldSchema> list = new ArrayList<>();
+
+        for (int i = 0; i < json.length(); i++){
+            JSONObject obj = (JSONObject) json.get(i);
+
+            FieldSchema fs = new FieldSchema();
+
+            fs.setName(obj.getString("name"));
+            fs.setType(obj.getString("type"));
+
+            if (obj.getBoolean("setComment"))
+                fs.setComment(obj.getString("comment"));
+
+            list.add(fs);
+        }
+
+        return list;
+    }
+
+    public void closeCache() {
+        if (jedis != null) {
+            System.out.println("closing cache connection");
+            jedis.close();
+        }
+    }
+}

--- a/src/main/java/com/mcneilio/shokuyoku/util/OrcJSONSchemaDictionaryCache.java
+++ b/src/main/java/com/mcneilio/shokuyoku/util/OrcJSONSchemaDictionaryCache.java
@@ -29,7 +29,9 @@ public class OrcJSONSchemaDictionaryCache {
             String sslEnabled = System.getenv("REDIS_SSL_ENABLED");
             String port = System.getenv("REDIS_PORT");
 
-            jedis = new JedisPooled(host, Integer.parseInt(port), Boolean.parseBoolean(sslEnabled));
+            jedis = (Boolean.parseBoolean(sslEnabled)) ?
+                    new JedisPooled(host, Integer.parseInt(port), true) :
+                    new JedisPooled(host, Integer.parseInt(port), false);
         } catch (Exception ex) {
             System.out.println("Error instantiating and connecting to the REDIS cache: " + ex);
             ex.printStackTrace();
@@ -102,6 +104,11 @@ public class OrcJSONSchemaDictionaryCache {
             }
 
             System.out.println("Executors completed");
+
+            if (System.getenv("VALIDATE_CACHE") != null && System.getenv("VALIDATE_CACHE").equalsIgnoreCase("true")){
+                for (String eventName : getEventNameList())
+                    System.out.println(eventName + ": " + jedis.get(eventName));
+            }
         }
         catch(Exception ex){
             System.err.println("ex");


### PR DESCRIPTION
Adding the capability to use a REDIS cache to store the Hive Metastore data, which will enable the many instances of the Filter to load from the REDIS cache, instead of overloading the hive metastore service and underlying database.